### PR TITLE
feat: 添加新的 slot，可以自定义展开收起按钮

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ import VueChartTree, { resetTree, updatePartTree } from 'vue-chart-tree'
 组件本身只是构建了一个树状结构，以及基本的交互，树状图上的节点由开发者自行决定，通过一个传入的 `default slot` 实现，所以具备较大的灵活性
 具体用法参见 [demo](https://github.com/accforgit/vue-chart-tree/blob/master/test/chart-tree.vue)
 
+|slot|描述|参数|
+|----|---|----|
+|`default`|默认插槽，自定义树的节点|{ data: { treeNodeData, $treeNodeRefs } }|
+|`fold`|自定义展开和收起按钮|{ data: { treeNodeData, $treeNodeRefs } }|
+
 ## License
 
 MIT

--- a/src/vue-chart-tree.vue
+++ b/src/vue-chart-tree.vue
@@ -12,7 +12,10 @@
   <!-- 控制展开/收缩的节点 -->
   <div :class="stretchNodeClassName" v-if="childrenLen">
     <p class="line_l"></p>
-    <p :class="['line_dot', treeNodeData.isOpen ? 'cut_dot' : 'add_dot']" @click="changeOpen"></p>
+    <p v-if="!$scopedSlots.fold" :class="['line_dot', treeNodeData.isOpen ? 'cut_dot' : 'add_dot']" @click="changeOpen"></p>
+    <p v-else class="custom_line_dot" @click="changeOpen">
+      <slot name="fold" v-bind:data="{ treeNodeData, $treeNodeRefs: $refs }"></slot>
+    </p>
   </div>
   <div
     :class="treeChildrenClassName"
@@ -25,6 +28,9 @@
       :key="item.id"
       :treeNodeData="item"
       :isRoot="false">
+      <template v-if="$scopedSlots.fold" v-slot:fold="slotProps">
+        <slot name="fold" v-bind:data="slotProps.data"></slot>
+      </template>
       <template v-slot:default="slotProps">
         <slot v-bind:data="slotProps.data"></slot>
       </template>
@@ -77,7 +83,6 @@ export default {
   },
   mounted() {
     if (this.isRoot) {
-      console.log(this.$refs.treeNodeRef)
       resetTree(this.$refs.treeNodeRef)
     }
   },
@@ -144,6 +149,12 @@ export default {
       &.cut_dot {
         background-image: ~"url('./assets/cut-round.png')";
       }
+    }
+    .custom_line_dot {
+      position: relative;
+      width: @stretchNodeH;
+      height: @stretchNodeH;
+      cursor: pointer;
     }
   }
   .line_l, .line_r {

--- a/test/chart-tree.vue
+++ b/test/chart-tree.vue
@@ -15,6 +15,13 @@
             </div>
           </div>
         </template>
+        <template v-slot:fold="slotProps">
+          <div class="fold">
+            <span class="fold_num"> {{slotProps.data.treeNodeData.children && slotProps.data.treeNodeData.children.length}} </span>
+            <span v-if="slotProps.data.treeNodeData.isOpen" class="fold_indicator"> 收起 </span>
+            <span v-else class="fold_indicator"> 展开 </span>
+          </div>
+        </template>
       </vue-chart-tree>
     </div>
     <div class="name_dialog" v-if="nameModalVisible">
@@ -149,6 +156,33 @@ function genTestName() {
     bottom: 0;
     background-color: rgba(0, 0, 0, 0.65);
     z-index: 100
+  }
+}
+.fold {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 12px;
+  color: #666;
+  height: 22px;
+  min-width: 22px;
+  border: 2px solid #CCC;
+  border-radius: 12px;
+  background-color: white;
+  &_indicator {
+    display: none;
+  }
+  &:hover {
+    .fold_num {
+      display: none;
+    }
+    .fold_indicator {
+      display: inline-block;
+    }
   }
 }
 </style>


### PR DESCRIPTION
添加了新的 slot `fold` （这个名称可以商榷），用于自定义展开收起按钮。

可以实现如下效果(代码在 `test/chart-tree.vue`)：

![iShot2021-12-14 11 12 55](https://user-images.githubusercontent.com/13328625/145926493-1affd5eb-9ec6-4dab-aa28-cc073f9aacd1.gif)

