### PR TITLE
refactor: 显示子节点的方式由 v-show -> v-if

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -320,7 +320,7 @@ function isRootTreeNode (treeNode) {
   return treeNode.parentElement.className.indexOf(treeChildrenClassName) === -1
 }
 
-function isOpened (treeNode) {
+export function isOpened (treeNode) {
   return treeNode.getAttribute('data-' + dataOpened.key) === dataOpened.opened
 }
 function setDataOpened (treeNode) {

--- a/src/vue-chart-tree.vue
+++ b/src/vue-chart-tree.vue
@@ -16,7 +16,7 @@
   </div>
   <div
     :class="treeChildrenClassName"
-    v-if="childrenLen"
+    v-if="childrenLen && openedChildren"
     v-show="treeNodeData.isOpen"
   >
     <p :class="connectLineClassName" v-if="childrenLen > 1"></p>
@@ -37,7 +37,7 @@ import {
   dataOpened,
   treeParentClassName, treeChildrenClassName, treeNodeClassName, stretchNodeClassName, connectLineClassName
 } from './const'
-import { resetTree, updatePartTree } from './util'
+import { resetTree, updatePartTree, isOpened } from './util'
 
 export default {
   name: 'vue-chart-tree',
@@ -69,7 +69,11 @@ export default {
   computed: {
     childrenLen () {
       return (this.treeNodeData.children || []).length
-    }
+    },
+    // 会被打开或被打开过
+    openedChildren() {
+      return this.treeNodeData.isOpen || (this.$refs.treeNodeRef && isOpened(this.$refs.treeNodeRef))
+    },
   },
   mounted() {
     if (this.isRoot) {


### PR DESCRIPTION
场景：节点是自定义组件时，组件 created 会调用接口，导致接口数据量过大。

> 接口做了聚合，多个节点的接口调用会聚合成一次 http 调用，这边主要是数据量过大，不是接口调用次数多。

解决： 右 v-show -> v-if 可以避免，同时首次加载的性能也会提高一些。